### PR TITLE
Make luminosity unit configurable

### DIFF
--- a/src/cmsstyle/cmsstyle.py
+++ b/src/cmsstyle/cmsstyle.py
@@ -17,11 +17,11 @@ def SetEnergy(energy):
     cms_energy = str(energy)
 
 
-def SetLumi(lumi, round_lumi=False):
+def SetLumi(lumi, unit="fb", round_lumi=False):
     global cms_lumi
     if lumi != "":
         cms_lumi = f"{lumi:.0f}" if round_lumi else f"{lumi}"
-        cms_lumi += " fb^{#minus1}"
+        cms_lumi += f" {unit}^{{#minus1}}"
     else:
         cms_lumi = lumi
 


### PR DESCRIPTION
Fixes #26 

Rather than using

```python
if type(lumi)==float: 
        cms_lumi = f"{lumi:.0f}" if round_lumi else f"{lumi}"
        cms_lumi += " fb^{#minus1}"
elif type(lumi)==str:
        cms_lumi=lumi
```

as suggested in #26, I think that only changing the unit itself but without the `-1` exponent might be safer to prevent people from accidentally using different `^-1`. Let me know what you think, @pfs.