### PR TITLE
Fixing problems with TColorDefined (in saved TCanvas as root files), other visualization problems (stats box, y-title offset) and adding a new drawing method

### DIFF
--- a/src/cmsstyle/cmsstyle.py
+++ b/src/cmsstyle/cmsstyle.py
@@ -443,6 +443,15 @@ def setCMSStyle(force=rt.kTRUE):
     cmsStyle.SetPaperSize(20.0, 20.0)
     cmsStyle.SetHatchesLineWidth(5)
     cmsStyle.SetHatchesSpacing(0.05)
+
+    # Some additional parameters we need to set as "style"
+
+    if (float('.'.join(rt.__version__.split('.')[0:2])) < 6.32):  # Not available before!
+        # This allows to save inside the canvas the informnation about the
+        # defined colours.
+        rt.TColor.DefinedColors(1)
+
+    # Using the Style.
     cmsStyle.cd()
 
 


### PR DESCRIPTION
The changes are inteded to fix the following issues:

    + The problem of the defined colours not saved in TCanvas saved in ROOT files, available from version 6.32 (the code incluye a control on this to prevent crashes in 6.30)

    + Fixing a problem to allow showing the stats box with cmsDraw by moving the forced "SAME" to the beginning as if set at the end, it was hiding the box as not being the first histogram to be plotted (and the use of "SAMES" was not possible).

    + Changing the default positions (very slightly, this is not fully backward compatible, but impact is minor) of the title in the Y axis, as the previous values were not completely tuned. Although no fully backward compatible, a new addition (below) allows to recover the previous behaviour (i.e. values) easily.

And to add new capabilities (fully backward compatible):

    + New method cmsObjectDraw allowing to plot *any* kind of ROOT object with an unified method and a more pythyonic way of dealing with the plotting characteristics (more flexible and scalable) of the plotting object. Totally independent of the rest of the code.
    
    + New argument added to cmsCanvas to set by hand the value of the offset for the Y title, as it was hard to change it automatically for all cases. The default values that were hardcoded were not fine with quantities in the axis with more that 2 digits. The default currently does not recover the previous default, but the new prectical one. Using a value of 1.2 (0.8) for square (rectangular) canvas would recover the previous values.