### PR TITLE
Introduce support for subplots

### DIFF
--- a/tests/test_subplots.py
+++ b/tests/test_subplots.py
@@ -1,0 +1,98 @@
+import ROOT
+import cmsstyle
+import math
+
+def _create_drawables():
+    """Create some graphics to draw later."""
+    _ = ROOT.TF1("fsignal", "TMath::Gaus(x,0,0.5)", -2, 2)
+    signal = ROOT.TH1D("signal", "Histogram", 20, -2, 2)
+    signal.FillRandom("fsignal", 1000)
+
+    bkg = ROOT.TH1D("bkg", "Histogram", 20, -2, 2)
+    bkg.FillRandom("pol0", 1000)
+
+    data = ROOT.TH1D("data", "Histogram", 20, -2, 2)
+    data.FillRandom("fsignal", 1000)
+    data.FillRandom("pol0", 1000)
+
+    bkg_tot = bkg + signal
+
+    h_err = bkg_tot.Clone("h_err")
+
+    ratio = data.Clone("ratio")
+    ratio.Divide(bkg_tot)
+
+    for i in range(1, ratio.GetNbinsX()+1):
+        if (ratio.GetBinContent(i)):
+            ratio.SetBinError(i, math.sqrt(data.GetBinContent(i))/bkg_tot.GetBinContent(i))
+        else:
+            ratio.SetBinError(i, 10 ^ (-99))
+
+    yerr_root = ROOT.TGraphAsymmErrors()
+    yerr_root.Divide(data, bkg_tot, 'pois')
+
+    for i in range(0, yerr_root.GetN()+1):
+        yerr_root.SetPointY(i, 1)
+    ref_line = ROOT.TLine(-2, 1, 2, 1)
+
+    hs = ROOT.THStack("hstack", "STACK")
+    hs.Add(bkg)
+    hs.Add(signal)
+
+    # Some graphical attributes here, usually dealt via cmsstyle functions
+    signal.SetFillColor(ROOT.kP6Blue)
+    bkg.SetFillColor(ROOT.kP6Yellow)
+    data.SetFillColor(ROOT.kP6Blue)
+
+    return data, hs, h_err, ratio, yerr_root, ref_line, bkg, signal
+
+
+def test_subplots():
+    """Example of multiple plots in the same canvas, with shared common legend"""
+    ncolumns = 2
+    nrows = 6
+    cvm = cmsstyle.subplots(
+        ncolumns=ncolumns,
+        nrows=nrows,
+        height_ratios=[3, 1] * (nrows // 2),
+        canvas_top_margin=0.1,
+        canvas_bottom_margin=0.03)
+
+    data, hs, h_err, ratio, yerr_root, ref_line, bkg, signal = _create_drawables()
+
+    cvm.plot_common_legend(
+        cvm.top_pad,
+        cmsstyle.LegendItem(data, "Data", "pe"),
+        cmsstyle.LegendItem(bkg, "MC1", "f"),
+        cmsstyle.LegendItem(signal, "MC2", "f"),
+        cmsstyle.LegendItem(ratio, "Ratio", "pe"))
+    cvm.plot_text(
+        cvm.top_pad,
+        "Run 2, 138 fb^{#minus1}",
+        textsize=0.3,
+        textalign=33)
+    cvm.plot_text(
+        cvm.bottom_pad,
+        "m^{ll} (GeV)",
+        textsize=1,
+        textalign=33)
+    cvm.ylabel("Test")
+
+    row_index = -1
+    for i, pad in enumerate(cvm.pads):
+        if i % ncolumns == 0:
+            row_index += 1
+        if row_index % 2 == 0:
+            pad.plot(hs)
+            pad.plot(h_err, "E2SAME0", FillColor=ROOT.kBlack, LineWidth=1, LineColor=355, FillStyle=3004)
+            pad.plot(data, "E1X0", FillColor=ROOT.kP6Blue)
+        else:
+            pad.plot(yerr_root, "E2SAME0", LineWidth=100, MarkerSize=0, FillColor=ROOT.kBlack, FillStyle=3004)
+            pad.plot(ratio, "E1X0")
+            pad.plot(ref_line, LineColor=ROOT.kBlack, LineStyle=ROOT.kDotted)
+
+    cvm.save_figure("cmsstyle_subplots.png")
+
+
+if __name__ == "__main__":
+    test_subplots()


### PR DESCRIPTION
This commit introduces support for plotting multiple subplots in the same canvas. A new function aptly called `subplots` lets the user specify a grid layout in which to split the main canvas and returns an object through which the canvas and its subcomponents can be managed for plotting. Various configuration options are available, such as specifying extra space at the top or bottom of the canvas for extra pads which could host e.g. a shared common legend for all the subplots. Two new classes are also introduced. CMSCanvasManager is the type returned by the `subplots` function. It stores all the pads created and gives access to them. Each pad is of type CMSPad, the second main class introduced, which exposes a plot method to plot graphics onto that specific pad, without needing to interact with internal ROOT mechanisms such as gPad.

Fixes https://github.com/cms-cat/cmsstyle/issues/52


Note that I have added a test and if I execute it locally I get the following image, let me know if it's well placed as is or I should touch somewhere else
![cmsstyle_subplots](https://github.com/user-attachments/assets/7716bfcc-ad34-43e1-93e0-656eed37f920)
