### PR TITLE
Set ownership for TLegend header in cmsstyle.py

### DIFF
--- a/src/cmsstyle/cmsstyle.py
+++ b/src/cmsstyle/cmsstyle.py
@@ -1316,6 +1316,9 @@ def cmsHeader(
         leg.GetListOfPrimitives().AddAt(header, 0)
     else:
         leg.GetListOfPrimitives().AddLast(header)
+    # ROOT >= 6.40 no longer drops Python ownership automatically for this case.
+    # The entry is stored in the TLegend primitive list, so avoid Python GC deleting it.
+    rt.SetOwnership(header, False)
 
 
 # ########  ########     ###    ##      ##


### PR DESCRIPTION
Prevent Python garbage collection from deleting TLegend header. This PR addresses issue https://github.com/cms-cat/cmsstyle/issues/77, which is caused by a new ownership behavior introduced in ROOT v6.40 https://root.cern.ch/doc/v640/release-notes.html#change-in-memory-ownership-heuristics. The fix was suggested by @aapo-kossi.